### PR TITLE
removes quotes from link to user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Version 2.0.0 is available at commit 1d61e4672fa24eb2cec1083c69b00fba255dd6f9,
 released on April 7, 2020 based on information locked on April 4, 2020. 
 
 ### User Guide
-[102247 Rev A AW, Verily Pathfinder Virtual Agent Template for COVID-19 User Guide.pdf]("/agent-template/102247%20Rev%20A%20AW%2C%20Verily%20Pathfinder%20Virtual%20Agent%20Template%20for%20COVID-19%20User%20Guide.pdf")
+[102247 Rev A AW, Verily Pathfinder Virtual Agent Template for COVID-19 User Guide.pdf](/agent-template/102247%20Rev%20A%20AW%2C%20Verily%20Pathfinder%20Virtual%20Agent%20Template%20for%20COVID-19%20User%20Guide.pdf)
 
 ### Notice on Version 2.0.0 of COVID-19 Pathfinder virtual agent template
 [102253 Rev A AP, Integration Version Letter, Verily COVID-19 Pathfinder v2.0.0.pdf](/agent-template/102253%20Rev%20A%20AP%2C%20Integration%20Version%20Letter%2C%20Verily%20COVID-19%20Pathfinder%20v2.0.0.pdf)


### PR DESCRIPTION
Link to user guide included `"` symbols resulting in a 404